### PR TITLE
Fix GitHub Actions workflow: Switch to ubuntu-latest runner

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -25,7 +25,7 @@ defaults:
 jobs:
   test:
     name: Test (Python)
-    runs-on: ibm-x86-64-large
+    runs-on: ubuntu-latest
 
     # Skip CI for draft PRs
     if: ${{ github.event.pull_request.draft == false }}


### PR DESCRIPTION
Updates the GitHub Actions workflow to use `ubuntu-latest` instead of the custom `ibm-x86-64-large` runner for Python testing jobs.